### PR TITLE
Add config management related endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ cover/
 *.pot
 
 # Django stuff:
-*.log
+*.log*
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,9 @@ pre-commit==2.15.0
 coverage==5.5
 lxml==4.6.3
 mypy==0.910
+python-multipart==0.0.5
+aiofiles==0.7.0
+types-requests==2.25.9
 
 # Workaround https://github.com/tiangolo/fastapi/issues/2595
 requests==2.26.0

--- a/serverctl_deployd/models/config.py
+++ b/serverctl_deployd/models/config.py
@@ -6,7 +6,7 @@ from typing import Optional, Set
 
 from pydantic import BaseModel
 from pydantic.fields import Field
-from pydantic.types import DirectoryPath, FilePath
+from pydantic.types import DirectoryPath
 
 
 class ListConfigBucket(BaseModel):
@@ -37,14 +37,4 @@ class ConfigBucket(BaseModel):
     )
     update_command: Optional[str] = Field(
         None, title="Command to be run to reload the config file(s)"
-    )
-
-
-class ConfigFile(BaseModel):
-    """Class for config file"""
-    file_path: FilePath = Field(
-        ..., title="Path of config file"
-    )
-    update_command: str = Field(
-        ..., title="Command to be run to reload the config file(s)"
     )

--- a/serverctl_deployd/models/config.py
+++ b/serverctl_deployd/models/config.py
@@ -1,0 +1,50 @@
+"""
+Models for config buckets
+"""
+
+from typing import Optional, Set
+
+from pydantic import BaseModel
+from pydantic.fields import Field
+from pydantic.types import DirectoryPath, FilePath
+
+
+class ListConfigBucket(BaseModel):
+    """Class for obtaining list of files for a config bucket"""
+    directory_path: DirectoryPath = Field(
+        ..., title="Directory path for the bucket",
+        description="This is the path of the directory\
+            in which the config file(s) reside"
+    )
+    ignore_patterns: Optional[Set[str]] = Field(
+        None, title="List of unix-shell style patterns for files to be ignored",
+        description="Files which match this pattern will be ignored.\
+            The expressions in this list should follow glob syntax"
+    )
+
+
+class ConfigBucket(BaseModel):
+    """Class for validating config bucket creation and updation"""
+    directory_path: DirectoryPath = Field(
+        None, title="Directory path for the bucket",
+        description="This is the path of the directory\
+            in which the config file(s) reside"
+    )
+    ignore_patterns: Optional[Set[str]] = Field(
+        None, title="List of unix-shell style patterns for files to be ignored",
+        description="Files which match this pattern will be ignored.\
+            The expressions in this list should follow glob syntax"
+    )
+    update_command: Optional[str] = Field(
+        None, title="Command to be run to reload the config file(s)"
+    )
+
+
+class ConfigFile(BaseModel):
+    """Class for config file"""
+    file_path: FilePath = Field(
+        ..., title="Path of config file"
+    )
+    update_command: str = Field(
+        ..., title="Command to be run to reload the config file(s)"
+    )

--- a/serverctl_deployd/models/config.py
+++ b/serverctl_deployd/models/config.py
@@ -38,3 +38,10 @@ class ConfigBucket(BaseModel):
     update_command: Optional[str] = Field(
         None, title="Command to be run to reload the config file(s)"
     )
+
+
+class UpdateCommand(BaseModel):
+    """Class for update command"""
+    update_command: str = Field(
+        ..., title="Command to be run to reload the config file(s)"
+    )

--- a/serverctl_deployd/routers/config.py
+++ b/serverctl_deployd/routers/config.py
@@ -17,8 +17,7 @@ from fastapi.responses import FileResponse
 from pydantic.types import DirectoryPath, FilePath
 from starlette.responses import Response
 
-from serverctl_deployd.models.config import (ConfigBucket, ConfigFile,
-                                             ListConfigBucket)
+from serverctl_deployd.models.config import ConfigBucket, ListConfigBucket
 from serverctl_deployd.models.exceptions import GenericError
 
 
@@ -175,7 +174,7 @@ async def get_file(file_path: FilePath) -> FileResponse:
     }
 )
 async def update_file(
-    file_path: FilePath = Body(...),
+    file_path: FilePath,
     update_command: str = Body(...),
     new_file: UploadFile = File(...)
 ) -> FileResponse:
@@ -204,12 +203,15 @@ async def update_file(
     },
     status_code=status.HTTP_204_NO_CONTENT
 )
-def delete_file(config_file: ConfigFile) -> Response:
+def delete_file(
+    file_path: FilePath,
+    update_command: str = Body(..., embed=True)
+) -> Response:
     """Deletes the requested config file"""
-    config_file.file_path.unlink()
+    file_path.unlink()
     try:
         subprocess.run(
-            config_file.update_command,
+            update_command,
             shell=True,
             executable="/bin/bash",
             check=True

--- a/serverctl_deployd/routers/config.py
+++ b/serverctl_deployd/routers/config.py
@@ -17,7 +17,8 @@ from fastapi.responses import FileResponse
 from pydantic.types import DirectoryPath, FilePath
 from starlette.responses import Response
 
-from serverctl_deployd.models.config import ConfigBucket, ListConfigBucket
+from serverctl_deployd.models.config import (ConfigBucket, ListConfigBucket,
+                                             UpdateCommand)
 from serverctl_deployd.models.exceptions import GenericError
 
 
@@ -205,13 +206,13 @@ async def update_file(
 )
 def delete_file(
     file_path: FilePath,
-    update_command: str = Body(..., embed=True)
+    update_command: UpdateCommand
 ) -> Response:
     """Deletes the requested config file"""
     file_path.unlink()
     try:
         subprocess.run(
-            update_command,
+            update_command.update_command,
             shell=True,
             executable="/bin/bash",
             check=True

--- a/serverctl_deployd/routers/config.py
+++ b/serverctl_deployd/routers/config.py
@@ -2,6 +2,221 @@
 Router for Config routes
 """
 
-from fastapi import APIRouter
+import subprocess
+import tarfile
+from fnmatch import fnmatch
+from hashlib import sha256
+from io import BytesIO
+from os import DirEntry, scandir
+from typing import Any, Dict, List, Optional, Set
 
-router = APIRouter()
+from fastapi import APIRouter, Body, File, status
+from fastapi.datastructures import UploadFile
+from fastapi.exceptions import HTTPException
+from fastapi.responses import FileResponse
+from pydantic.types import DirectoryPath, FilePath
+from starlette.responses import Response
+
+from serverctl_deployd.models.config import (ConfigBucket, ConfigFile,
+                                             ListConfigBucket)
+from serverctl_deployd.models.exceptions import GenericError
+
+
+def _list_files(path: DirectoryPath,
+                patterns: Optional[Set[str]]) -> List[DirEntry[str]]:
+    """
+    Get a list of DirEntry objects for a path,
+    to be used by other functions
+    """
+    file_list: List[DirEntry[str]] = []
+    with scandir(path) as listing:
+        for entry in listing:
+            if entry.is_file():
+                if not patterns or not any(
+                    fnmatch(entry.name, pattern)
+                    for pattern in patterns
+                ):
+                    file_list.append(entry)
+    return file_list
+
+
+def _get_hashes(path: DirectoryPath,
+                patterns: Optional[Set[str]]) -> Dict[str, str]:
+    """
+    Get hashes of files in a directory whose file names do not
+    match the glob patterns
+    """
+    file_hash_list: Dict[str, str] = {}
+    for entry in _list_files(path, patterns):
+        file_hash = sha256()
+        byte_array = bytearray(128 * 1024)
+        memory_view = memoryview(byte_array)
+        with open(entry.path, 'rb', buffering=0) as conf_file:
+            for buffer_size in iter(
+                lambda cf=conf_file, mv=memory_view:  # type: ignore
+                cf.readinto(mv), 0
+            ):
+                file_hash.update(memory_view[:buffer_size])
+        file_hash_str = file_hash.hexdigest()
+        file_hash_list.update({entry.name: file_hash_str})
+    return file_hash_list
+
+
+router = APIRouter(
+    prefix="/config/buckets",
+    tags=["config"]
+)
+
+
+@router.post(
+    "/",
+    responses={
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": GenericError}
+    },
+    response_model=Dict[str, str]
+)
+def validate_bucket(config_bucket: ConfigBucket) -> Dict[str, str]:
+    """
+    Checks if the directory path and config updation command are valid.
+    If valid then returns a list of files and its hashes
+    """
+    if config_bucket.update_command:
+        try:
+            subprocess.run(
+                config_bucket.update_command,
+                shell=True,
+                executable="/bin/bash",
+                check=True
+            )
+        except subprocess.SubprocessError as execution_error:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Internal server error"
+            ) from execution_error
+    return _get_hashes(
+        config_bucket.directory_path,
+        config_bucket.ignore_patterns
+    )
+
+
+@router.post("/files", response_model=List[str])
+def list_filenames(config_bucket: ListConfigBucket) -> List[str]:
+    """Return list of file names for a config bucket"""
+    filename_list = [
+        entry.name for entry in _list_files(
+            config_bucket.directory_path,
+            config_bucket.ignore_patterns
+        )
+    ]
+    return filename_list
+
+
+@router.post("/check", response_model=Dict[str, str])
+def get_hashes(config_bucket: ListConfigBucket) -> Dict[str, str]:
+    """
+    Return list of file names for a bucket and their sha256 checksums
+    which will be verified by the serverctl API
+    """
+    return _get_hashes(
+        config_bucket.directory_path,
+        config_bucket.ignore_patterns
+    )
+
+
+@router.post(
+    "/backup",
+    responses={
+        status.HTTP_200_OK: {
+            "content": {"application/x-tar": {}}
+        }
+    },
+    response_class=Response
+)
+def get_tar_archive(
+    config_bucket: ListConfigBucket
+) -> Response:
+    """Returns the tar archive of config folder for backup"""
+    file_list = _list_files(
+        config_bucket.directory_path,
+        config_bucket.ignore_patterns
+    )
+    size = sum(entry.stat().st_size for entry in file_list)
+    byte_array = bytearray(size)
+    file_object = BytesIO(byte_array)
+    with tarfile.open(mode="w:gz", fileobj=file_object) as tar_file:
+        for entry in file_list:
+            tar_file.add(entry.path, arcname=entry.name)
+    return Response(
+        content=file_object.getvalue(),
+        media_type="application/x-tar"
+    )
+
+
+@router.get(
+    "/file", response_class=FileResponse,
+    responses={
+        status.HTTP_200_OK: {
+            "content": {"text/plain": {}}
+        }
+    }
+)
+async def get_file(file_path: FilePath) -> FileResponse:
+    """Returns the requested config file"""
+    return FileResponse(file_path)
+
+
+@router.put(
+    "/file", response_class=FileResponse,
+    responses={
+        status.HTTP_200_OK: {
+            "content": {"text/plain": {}}
+        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": GenericError}
+    }
+)
+async def update_file(
+    file_path: FilePath = Body(...),
+    update_command: str = Body(...),
+    new_file: UploadFile = File(...)
+) -> FileResponse:
+    """Updates the requested config file"""
+    new_content: Any = await new_file.read()
+    file_path.write_bytes(new_content)
+    try:
+        subprocess.run(
+            update_command,
+            shell=True,
+            executable="/bin/bash",
+            check=True
+        )
+    except subprocess.SubprocessError as execution_error:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error"
+        ) from execution_error
+    return FileResponse(file_path)
+
+
+@router.delete(
+    "/file",
+    responses={
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": GenericError}
+    },
+    status_code=status.HTTP_204_NO_CONTENT
+)
+def delete_file(config_file: ConfigFile) -> Response:
+    """Deletes the requested config file"""
+    config_file.file_path.unlink()
+    try:
+        subprocess.run(
+            config_file.update_command,
+            shell=True,
+            executable="/bin/bash",
+            check=True
+        )
+    except subprocess.SubprocessError as execution_error:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error"
+        ) from execution_error
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/tests/fakes/fake_config_directory.py
+++ b/tests/fakes/fake_config_directory.py
@@ -1,0 +1,26 @@
+"""
+A module to create a mock config file directory for testing purposes
+"""
+
+from pathlib import Path
+
+MOCK_CONF_DIRPATH = "tests/fakes/mock_confs/"
+MOCK_CONF_FILEPATH = MOCK_CONF_DIRPATH + "mock.conf"
+MOCK_CONF_FILE_CONTENT = "FakeSetting   fake-value"
+MOCK_CONF_NEW_CONTENT = "FakeSetting   updated-fake-value"
+MOCK_FILE_HASH = "d91a2831aff3a24753083d87786d7f8e8703f9f4612e15ae6f7939c37a2df954"
+
+
+def make_mock_config_dir() -> None:
+    """Make a mock config file directory and add mock conf files"""
+    Path(MOCK_CONF_DIRPATH).mkdir(exist_ok=True)
+    with open(
+        MOCK_CONF_FILEPATH,
+        'w', encoding='utf8'
+    ) as conf_file:
+        conf_file.write(MOCK_CONF_FILE_CONTENT)
+    with open(
+        MOCK_CONF_DIRPATH + 'leave_this.conf',
+        'w', encoding='utf8'
+    ) as conf_file:
+        conf_file.write(MOCK_CONF_FILE_CONTENT)

--- a/tests/routers/test_config.py
+++ b/tests/routers/test_config.py
@@ -32,9 +32,7 @@ def test_validate_bucket() -> None:
         json={
             "directory_path": MOCK_CONF_DIRPATH,
             "update_command": "echo updated",
-            "ignore_patterns": [
-                "leave*"
-            ]
+            "ignore_patterns": ["leave*"]
         })
     assert response.status_code == 200
     assert response.json() == {
@@ -69,9 +67,7 @@ def test_list_filenames() -> None:
             "ignore_patterns": ["leave*"]
         })
     assert response.status_code == 200
-    assert response.json() == [
-        "mock.conf"
-    ]
+    assert response.json() == ["mock.conf"]
 
     rmtree(MOCK_CONF_DIRPATH)
 

--- a/tests/routers/test_config.py
+++ b/tests/routers/test_config.py
@@ -127,10 +127,8 @@ def test_update_file() -> None:
         # Valid request
         response: Response = client.put(
             "/config/buckets/file",
-            data={
-                "file_path": MOCK_CONF_FILEPATH,
-                "update_command": "echo updated"
-            },
+            params={"file_path": MOCK_CONF_FILEPATH},
+            data={"update_command": "echo updated"},
             files={"new_file": new_file},
         )
         assert response.status_code == 200
@@ -139,10 +137,8 @@ def test_update_file() -> None:
         # Unsuccessful or invalid command
         response = client.put(
             "/config/buckets/file",
-            data={
-                "file_path": MOCK_CONF_FILEPATH,
-                "update_command": "invalid command"
-            },
+            params={"file_path": MOCK_CONF_FILEPATH},
+            data={"update_command": "invalid command"},
             files={"new_file": new_file},
         )
         assert response.status_code == 500
@@ -166,10 +162,10 @@ def test_delete_file() -> None:
     # Valid request
     response: Response = client.delete(
         "/config/buckets/file",
-        json={
-            "file_path": MOCK_CONF_DIRPATH + "delete_this.conf",
-            "update_command": "echo updated"
-        }
+        params={
+            "file_path": MOCK_CONF_DIRPATH + "delete_this.conf"
+        },
+        json={"update_command": "echo updated"}
     )
     assert response.status_code == 204
     assert not Path(MOCK_CONF_DIRPATH + "delete_this.conf").is_file()
@@ -183,10 +179,10 @@ def test_delete_file() -> None:
     # Unsuccessful or invalid command
     response = client.delete(
         "/config/buckets/file",
-        json={
-            "file_path": MOCK_CONF_DIRPATH + "delete_this.conf",
-            "update_command": "invalid command"
-        }
+        params={
+            "file_path": MOCK_CONF_DIRPATH + "delete_this.conf"
+        },
+        json={"update_command": "invalid command"}
     )
     assert response.status_code == 500
     assert response.json() == {

--- a/tests/routers/test_config.py
+++ b/tests/routers/test_config.py
@@ -1,0 +1,225 @@
+"""
+Tests for config management routes
+"""
+
+import filecmp
+import os
+import tarfile
+from pathlib import Path
+from shutil import rmtree
+
+from fastapi.testclient import TestClient
+from requests.models import Response
+
+from serverctl_deployd.main import app
+from tests.fakes.fake_config_directory import (MOCK_CONF_DIRPATH,
+                                               MOCK_CONF_FILE_CONTENT,
+                                               MOCK_CONF_FILEPATH,
+                                               MOCK_CONF_NEW_CONTENT,
+                                               MOCK_FILE_HASH,
+                                               make_mock_config_dir)
+
+client = TestClient(app)
+
+
+def test_validate_bucket() -> None:
+    """Test config bucket validation"""
+    make_mock_config_dir()
+
+    # Valid request
+    response: Response = client.post(
+        "/config/buckets/",
+        json={
+            "directory_path": MOCK_CONF_DIRPATH,
+            "update_command": "echo updated",
+            "ignore_patterns": [
+                "leave*"
+            ]
+        })
+    assert response.status_code == 200
+    assert response.json() == {
+        "mock.conf": MOCK_FILE_HASH
+    }
+
+    # Unsuccessful or invalid command
+    response = client.post(
+        "/config/buckets/",
+        json={
+            "directory_path": MOCK_CONF_DIRPATH,
+            "update_command": "invalid command",
+            "ignore_patterns": ["leave*"]
+        })
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": "Internal server error"
+    }
+
+    rmtree(MOCK_CONF_DIRPATH)
+
+
+def test_list_filenames() -> None:
+    """Test for file name list route i.e /files"""
+    make_mock_config_dir()
+
+    # Valid request
+    response: Response = client.post(
+        "/config/buckets/files",
+        json={
+            "directory_path": MOCK_CONF_DIRPATH,
+            "ignore_patterns": ["leave*"]
+        })
+    assert response.status_code == 200
+    assert response.json() == [
+        "mock.conf"
+    ]
+
+    rmtree(MOCK_CONF_DIRPATH)
+
+
+def test_get_hashes() -> None:
+    """Test for the get hashes route i.e /check"""
+    make_mock_config_dir()
+
+    # Valid request
+    response: Response = client.post(
+        "/config/buckets/check",
+        json={
+            "directory_path": MOCK_CONF_DIRPATH,
+            "ignore_patterns": ["leave*"]
+        })
+    assert response.status_code == 200
+    assert response.json() == {
+        "mock.conf": MOCK_FILE_HASH
+    }
+
+    rmtree(MOCK_CONF_DIRPATH)
+
+
+def test_get_file() -> None:
+    """Test for getting config file"""
+    make_mock_config_dir()
+
+    # Valid request
+    response: Response = client.get(
+        "/config/buckets/file",
+        params={"file_path": MOCK_CONF_FILEPATH}
+    )
+    assert response.status_code == 200
+    assert response.content.decode() == MOCK_CONF_FILE_CONTENT
+
+    rmtree(MOCK_CONF_DIRPATH)
+
+
+def test_update_file() -> None:
+    """Test for updating config file"""
+    make_mock_config_dir()
+
+    with open(
+        MOCK_CONF_DIRPATH + "new_file.conf",
+        'w', encoding="utf8"
+    ) as new_file:
+        new_file.write(MOCK_CONF_NEW_CONTENT)
+
+    with open(
+        MOCK_CONF_DIRPATH + "new_file.conf",
+        'r', encoding="utf8"
+    ) as new_file:
+        # Valid request
+        response: Response = client.put(
+            "/config/buckets/file",
+            data={
+                "file_path": MOCK_CONF_FILEPATH,
+                "update_command": "echo updated"
+            },
+            files={"new_file": new_file},
+        )
+        assert response.status_code == 200
+        assert response.content.decode() == MOCK_CONF_NEW_CONTENT
+
+        # Unsuccessful or invalid command
+        response = client.put(
+            "/config/buckets/file",
+            data={
+                "file_path": MOCK_CONF_FILEPATH,
+                "update_command": "invalid command"
+            },
+            files={"new_file": new_file},
+        )
+        assert response.status_code == 500
+        assert response.json() == {
+            "detail": "Internal server error"
+        }
+
+    rmtree(MOCK_CONF_DIRPATH)
+
+
+def test_delete_file() -> None:
+    """Test for deleting config file"""
+    make_mock_config_dir()
+
+    with open(
+        MOCK_CONF_DIRPATH + "delete_this.conf",
+        'w', encoding="utf8"
+    ) as new_file:
+        new_file.write(MOCK_CONF_FILE_CONTENT)
+
+    # Valid request
+    response: Response = client.delete(
+        "/config/buckets/file",
+        json={
+            "file_path": MOCK_CONF_DIRPATH + "delete_this.conf",
+            "update_command": "echo updated"
+        }
+    )
+    assert response.status_code == 204
+    assert not Path(MOCK_CONF_DIRPATH + "delete_this.conf").is_file()
+
+    with open(
+        MOCK_CONF_DIRPATH + "delete_this.conf",
+        'w', encoding="utf8"
+    ) as new_file:
+        new_file.write(MOCK_CONF_FILE_CONTENT)
+
+    # Unsuccessful or invalid command
+    response = client.delete(
+        "/config/buckets/file",
+        json={
+            "file_path": MOCK_CONF_DIRPATH + "delete_this.conf",
+            "update_command": "invalid command"
+        }
+    )
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": "Internal server error"
+    }
+
+    rmtree(MOCK_CONF_DIRPATH)
+
+
+def test_get_tar_archive() -> None:
+    """Test for getting tar archive backup and verifying its contents"""
+    make_mock_config_dir()
+
+    response: Response = client.post(
+        "/config/buckets/backup",
+        json={"directory_path": MOCK_CONF_DIRPATH}
+    )
+    assert response.status_code == 200
+
+    with open("tests/fakes/mock_conf.tar.gz", "wb") as bin_file:
+        bin_file.write(response.content)
+    backup_path = Path("tests/fakes/backup_conf")
+    backup_path.mkdir(exist_ok=True)
+    with tarfile.open("tests/fakes/mock_conf.tar.gz", "r|gz") as tar_file:
+        tar_file.extractall(path=backup_path)
+    _, mismatch, error = filecmp.cmpfiles(
+        backup_path,
+        MOCK_CONF_DIRPATH,
+        ["mock.conf", "leave_this.conf"]
+    )
+    assert mismatch == []
+    assert error == []
+
+    os.remove("tests/fakes/mock_conf.tar.gz")
+    rmtree(backup_path)
+    rmtree(MOCK_CONF_DIRPATH)


### PR DESCRIPTION
* Added endpoint which validates config bucket info created or updated in serverctl API
* Added endpoint for retrieving file checksums which can be verified in serverctl for detecting file changes
* Added endpoint which returns a tar archive of config directory for backup purposes
* Added endpoints for reading, updating and deleting a config file
* Fix gitignore to ignore all logs

Closes #8 
